### PR TITLE
[minor](docs) edit connection initialization code snippet

### DIFF
--- a/src/doc/introduction/snippets/init.js
+++ b/src/doc/introduction/snippets/init.js
@@ -1,7 +1,7 @@
 const {shiphold} = require('ship-hold');
 const sh = shiphold({
     hostname: '127.0.0.1',
-    username: 'docker',
+    user: 'docker',
     password: 'docker',
     database: 'dev'
 });


### PR DESCRIPTION
This is honestly a very minor change 😅 . In the connection initialization configuration, `user` should be the correct key instead of `username`.
Using the `username` key causes the `user` option to default to `PGUSER` environment variable.
Awesome work btw 🎉 love the library.