### PR TITLE
Fix typo in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "data access framework for PostgreSQL",
   "main": "./dist/bundle/index",
   "module": "./dist/bundle/module",
-  "types": "./dist/declartions/index.d.ts",
+  "types": "./dist/declarations/index.d.ts",
   "files": [
     "dist/bundle",
     "dist/declarations"


### PR DESCRIPTION
Typo preventing typescript types from working?

